### PR TITLE
test: fix unit tests after clustering refactory

### DIFF
--- a/tests/src/core/ml/unsupervised/clustering/test_agglomerative.py
+++ b/tests/src/core/ml/unsupervised/clustering/test_agglomerative.py
@@ -39,14 +39,14 @@ def test_agglomerative():
     data = scaler.fit_transform(data)
 
     # Perform Agglomerative clustering
-    agglomerative = Agglomerative()
+    agglomerative = Agglomerative(3)
     agglomerative.fit(data)
 
     # Calculate silhouette score
     labels = agglomerative.labels
     silhouette_score_val = silhouette_score(data, labels, random_state=42)
 
-    assert abs(silhouette_score_val - 0.38969149409053977) < 1.0e-1  # For 3 clusters
+    assert abs(silhouette_score_val - 0.38969149409053977) < 1.0e-2  # For 3 clusters
 
 
 if __name__ == "__main__":

--- a/tests/src/core/ml/unsupervised/clustering/test_dbscan.py
+++ b/tests/src/core/ml/unsupervised/clustering/test_dbscan.py
@@ -39,7 +39,7 @@ def test_dbscan():
     data = scaler.fit_transform(data)
 
     # Perform DBSCAN clustering
-    dbscan = Dbscan()
+    dbscan = Dbscan(0.1617, 10)
     dbscan.fit(data)
 
     # Calculate silhouette score

--- a/tests/src/core/ml/unsupervised/clustering/test_gmm.py
+++ b/tests/src/core/ml/unsupervised/clustering/test_gmm.py
@@ -39,7 +39,7 @@ def test_gmm():
     data = scaler.fit_transform(data)
 
     # Perform GMM clustering
-    gmm = Gmm()
+    gmm = Gmm(3)
     gmm.fit(data)
 
     # Calculate silhouette score

--- a/tests/src/core/ml/unsupervised/clustering/test_hdbscan.py
+++ b/tests/src/core/ml/unsupervised/clustering/test_hdbscan.py
@@ -43,7 +43,7 @@ def test_hdbscan():
     hdbscan.fit(data)
 
     # Get number of clusters
-    n_clusters = hdbscan.n_clusters
+    n_clusters = hdbscan.n_clusters_
 
     # Assert that number of clusters is 2
     assert n_clusters == 2

--- a/tests/src/core/ml/unsupervised/clustering/test_kmeans.py
+++ b/tests/src/core/ml/unsupervised/clustering/test_kmeans.py
@@ -39,7 +39,7 @@ def test_kmeans():
     data = scaler.fit_transform(data)
 
     # Perform KMeans clustering
-    kmeans = Kmeans(max_k=10)
+    kmeans = Kmeans(2)
     kmeans.fit(data)
 
     # Calculate silhouette score


### PR DESCRIPTION
This PR fixes the unit tests that were not passing due to clustering refactory. Now arguments have been provided in clustering algorithms to reproduce and assert the silhouette score in the unit tests.